### PR TITLE
mctp: pcie-vdm: Fix MCTP control message parsing

### DIFF
--- a/drivers/net/mctp/mctp-pcie-vdm.c
+++ b/drivers/net/mctp/mctp-pcie-vdm.c
@@ -87,6 +87,7 @@ enum mctp_ctrl_command_code {
 };
 
 struct mctp_ctrl_msg_hdr {
+	u8 message_type;
 	u8 ctrl_msg_class;
 	u8 command_code;
 };


### PR DESCRIPTION
Currently MCTP control message parsing code incorrectly calculates offset of the Rq/D bits in the incoming message.
This is because the first byte of the MCTP control message is a "Message Type" byte and the relevant structure "mctp_ctrl_msg_hdr" is missing this field.
Add "u8 message_type" to the structure fields to fix the issue.