### PR TITLE
soc: aspeed: mctp: Fix FILTER_EID ioctl

### DIFF
--- a/drivers/soc/aspeed/aspeed-mctp.c
+++ b/drivers/soc/aspeed/aspeed-mctp.c
@@ -49,6 +49,7 @@
 
 #define ASPEED_MCTP_EID		0x014
 #define  MEMORY_SPACE_MAPPING	GENMASK(31, 28)
+#define  MCTP_EID		GENMASK(7, 0)
 #define ASPEED_MCTP_OBFF_CTRL	0x018
 
 #define ASPEED_MCTP_ENGINE_CTRL		0x01c
@@ -1546,7 +1547,8 @@ aspeed_mctp_filter_eid(struct aspeed_mctp *priv, void __user *userbuf)
 	}
 
 	if (eid.enable) {
-		regmap_write(priv->map, ASPEED_MCTP_EID, eid.eid);
+		regmap_update_bits(priv->map, ASPEED_MCTP_EID,
+				   MCTP_EID, eid.eid);
 		regmap_update_bits(priv->map, ASPEED_MCTP_CTRL,
 				   MATCHING_EID, MATCHING_EID);
 	} else {


### PR DESCRIPTION
Currently ASPEED_MCTP_IOCTL_FILTER_EID ioctl completely overwrites the ASPEED_MCTP_EID register with the input eid value. This is wrong since MCTP_EID is only in the lowest 8 bits of the register. Overwriting other bits can corrupt MCTP memory space mapping value and as a result break down all mctp communication and even the kernel itself.
To fix the issue use a bitmask to set only the relevant MCTP_EID bits.