### PR TITLE
Fix the macro definitions related to CPU and FMC reset.

### DIFF
--- a/drivers/watchdog/aspeed_wdt.c
+++ b/drivers/watchdog/aspeed_wdt.c
@@ -120,7 +120,7 @@ MODULE_DEVICE_TABLE(of, aspeed_wdt_of_table);
 #define   WDT_CTRL_BOOT_SECONDARY	BIT(7)
 #define   WDT_CTRL_RESET_MODE_SOC	(0x00 << 5)
 #define   WDT_CTRL_RESET_MODE_FULL_CHIP	(0x01 << 5)
-#define   WDT_CTRL_RESET_MODE_ARM_CPU	(0x10 << 5)
+#define   WDT_CTRL_RESET_MODE_ARM_CPU	(0x02 << 5)
 #define   WDT_CTRL_RST_SOC		BIT(4)
 #define   WDT_CTRL_1MHZ_CLK		BIT(4) /* AST2400 only */
 #define   WDT_CTRL_WDT_EXT		BIT(3)


### PR DESCRIPTION
Fix the macro definitions related to CPU and FMC reset.
For AST2500/AST2600,reset configuration for WDT0C of ARM/CPU(AST2500) or CPU/FMC(AST2600) is bit[6:5]=10b or 11b,so the vale should equal 0x02 << 5 or 0x03 << 5,not 0x10 << 5.